### PR TITLE
Bug fix in wrapper callable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### v1.3
++ Bug fix in WrapperCallable (loopover) for lists and arrays
+
 ### v1.2
 + Made executor and loopComposer (in DefaultMultiTask) protected for subclasses to use
 + Added another constructor to WrapperCallable for more flexibility

--- a/hydra-composer/pom.xml
+++ b/hydra-composer/pom.xml
@@ -8,12 +8,11 @@
     <description>Composer</description>
 
     <artifactId>hydra-composer</artifactId>
-    <version>1.2</version>
 
     <parent>
         <groupId>com.flipkart.hydra</groupId>
         <artifactId>hydra</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/hydra-dispatcher/pom.xml
+++ b/hydra-dispatcher/pom.xml
@@ -8,12 +8,11 @@
     <description>Dispatcher</description>
 
     <artifactId>hydra-dispatcher</artifactId>
-    <version>1.2</version>
 
     <parent>
         <groupId>com.flipkart.hydra</groupId>
         <artifactId>hydra</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/hydra-examples/pom.xml
+++ b/hydra-examples/pom.xml
@@ -8,12 +8,11 @@
     <description>Examples</description>
 
     <artifactId>hydra-examples</artifactId>
-    <version>1.2</version>
 
     <parent>
         <groupId>com.flipkart.hydra</groupId>
         <artifactId>hydra</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
 
     <dependencies>

--- a/hydra-expression/pom.xml
+++ b/hydra-expression/pom.xml
@@ -8,12 +8,11 @@
     <description>Expression</description>
 
     <artifactId>hydra-expression</artifactId>
-    <version>1.2</version>
 
     <parent>
         <groupId>com.flipkart.hydra</groupId>
         <artifactId>hydra</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/hydra-task/pom.xml
+++ b/hydra-task/pom.xml
@@ -8,12 +8,11 @@
     <description>Task</description>
 
     <artifactId>hydra-task</artifactId>
-    <version>1.2</version>
 
     <parent>
         <groupId>com.flipkart.hydra</groupId>
         <artifactId>hydra</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/hydra-task/src/main/java/com/flipkart/hydra/task/entities/WrapperCallable.java
+++ b/hydra-task/src/main/java/com/flipkart/hydra/task/entities/WrapperCallable.java
@@ -108,7 +108,7 @@ public class WrapperCallable implements Callable<Object> {
 
         List<Object> responsesList = new ArrayList<>();
         for (int i = 0; i < list.size(); i++) {
-            responsesList.add(futureMap.get(i));
+            responsesList.add(futureMap.get(i).get());
         }
 
         return responsesList;
@@ -128,7 +128,7 @@ public class WrapperCallable implements Callable<Object> {
 
         Object[] responsesArray = new Object[arr.length];
         for (int i = 0; i < arr.length; i++) {
-            responsesArray[i] = futureMap.get(i);
+            responsesArray[i] = futureMap.get(i).get();
         }
 
         return responsesArray;

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.flipkart.hydra</groupId>
     <artifactId>hydra</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
When loop over is used to iterate over a map/list/array and call a task iteratively, WrapperCallable is used by DefaultMultiTask. If its a list or array, it returns the future instead of the object returned by feature. Fixed it and bumped version to 1.3.

Will release to clojars post merge